### PR TITLE
Update `load_vmfb` to use new `from_flatbuffer` interface

### DIFF
--- a/python/iree_torch/__init__.py
+++ b/python/iree_torch/__init__.py
@@ -107,8 +107,8 @@ def load_vmfb(flatbuffer, backend="dylib"):
 
     The wrapper accepts and returns `torch.Tensor` types.
     """
-    vm_module = ireert.VmModule.from_flatbuffer(flatbuffer)
     config = ireert.Config(driver_name=_map_target_backend_to_driver(backend))
     ctx = ireert.SystemContext(config=config)
+    vm_module = ireert.VmModule.from_flatbuffer(ctx.instance, flatbuffer)
     ctx.add_vm_module(vm_module)
     return IREEInvoker(ctx.modules.module)


### PR DESCRIPTION
The interface for `VmModule.from_flatbuffer` in iree-runtime was
[recently changed](https://github.com/iree-org/iree/commit/9aa83eda3bd531ef74174cb7e7e7e9a1f4450336)
to take an instance argument in addition to the flatbuffer. This
commit updates `load_vmfb` to use this new interface.