### PR TITLE
Move most of torchbench.py code to new utils.py + bert.py example

### DIFF
--- a/torchdynamo_poc/bert.py
+++ b/torchdynamo_poc/bert.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Callable
+import torch
+import torchdynamo
+from transformers import BertConfig, AutoModelForMaskedLM
+
+from utils import check_results, print_time_stats, torch_mlir_compiler, timeit
+
+
+def run(func: Callable[[], List[torch.Tensor]], num_iter):
+    """Run a function a number of times."""
+    results = []
+    for _ in range(num_iter):
+        results += func()
+    return results
+
+
+def main():
+    max_length = 128
+    vocab_size = 2
+    input_tensor = torch.randint(0, vocab_size, (1, max_length))
+    config = BertConfig(vocab_size=vocab_size)
+    model = AutoModelForMaskedLM.from_config(config)
+    model.eval()
+
+    model_cpu = model.to("cpu")
+    input_cpu = input_tensor.to("cpu")
+
+    # TODO: make this an argument to the script
+    device = "cpu"
+    model_device = model.to(device)
+    input_device = input_tensor.to(device)
+
+    def compiler(graph, inputs):
+        return torch_mlir_compiler(graph, inputs, use_tracing=True, device=device)
+
+    compiled_iteration_times = []
+    eager_iteration_times = []
+
+    @timeit(append_time_to=compiled_iteration_times)
+    def run_model_compiled():
+        with torchdynamo.optimize(compiler):
+            return model_cpu.forward(input_cpu)["logits"]
+
+    @timeit(append_time_to=eager_iteration_times)
+    def run_model_eager():
+        with torchdynamo.optimize("eager"):
+            return model_device.forward(input_device)["logits"]
+
+    # TODO: make `num_iters` and `warmup_iters` argparse parameters
+    compiled_results = run(run_model_compiled, num_iter=10)
+    eager_results = run(run_model_eager, num_iter=10)
+
+    print("Compiled iteration times")
+    print_time_stats(compiled_iteration_times, warmup_iters=5)
+    print("Eager iteration times")
+    print_time_stats(eager_iteration_times, warmup_iters=5)
+
+    check_results(compiled_results, eager_results)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -1,0 +1,113 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import time
+from typing import List, Optional
+import torch
+
+import torch_mlir
+import iree_torch
+
+
+DEVICE_TO_IREE_BACKEND = { "cpu" : "dylib",
+                           "cuda" : "cuda" }
+
+
+def timeit(*, append_time_to: Optional[List] = None):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time_ns()
+            result = func(*args, **kwargs)
+            end_time = time.time_ns()
+
+            if append_time_to is not None:
+                append_time_to.append(end_time - start_time)
+            return result
+        return wrapper
+    return decorator
+
+
+def _returns_nothing(fx_g: torch.fx.GraphModule) -> bool:
+    for node in fx_g.graph.nodes:
+        if node.op == "output":
+            assert len(node.args) == 1, "Output node must have a single argument"
+            node_arg = node.args[0]
+            if isinstance(node_arg, tuple):
+                return len(node_arg) == 0
+    return False
+
+
+def _unwrap_single_tuple_return(fx_g: torch.fx.GraphModule) -> Optional[torch.fx.GraphModule]:
+    """Replace tuple with tuple element in functions that return one-element tuples."""
+    unwrapped_tuple = False
+    for node in fx_g.graph.nodes:
+        if node.op == "output":
+            assert len(node.args) == 1, "Output node must have a single argument"
+            node_arg = node.args[0]
+            if isinstance(node_arg, tuple):
+                if len(node_arg) == 1:
+                    node.args = (node_arg[0],)
+                    unwrapped_tuple = True
+                else:
+                    return None
+
+    if not unwrapped_tuple:
+        return None
+
+    fx_g.graph.lint()
+    fx_g.recompile()
+    return fx_g
+
+
+def torch_mlir_compiler(fx_graph: torch.fx.GraphModule,
+                        example_inputs: List[torch.Tensor],
+                        use_tracing: bool, device: str):
+    """Compile GraphModule using torch-mlir + IREE."""
+    if _returns_nothing(fx_graph):
+        return fx_graph
+
+    fx_graph_unwrapped = _unwrap_single_tuple_return(fx_graph)
+    was_unwrapped = fx_graph_unwrapped is not None
+    fx_graph = fx_graph_unwrapped if was_unwrapped else fx_graph
+    ts_compiler = torch.jit.trace if use_tracing else torch.jit.script
+    ts_graph = ts_compiler(fx_graph, example_inputs)
+    linalg_module = torch_mlir.compile(ts_graph, example_inputs,
+                                       output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)
+    backend = DEVICE_TO_IREE_BACKEND[device]
+    compiled_module = iree_torch.compile_to_vmfb(linalg_module, backend)
+    loaded_module = iree_torch.load_vmfb(compiled_module, backend)
+
+    def forward(*inputs):
+        result = loaded_module.forward(*inputs)
+        result = tuple() if result is None else result
+        return (result,) if was_unwrapped else result
+    return forward
+
+
+def check_results(compiled_results, eager_results):
+    for compiled_result, eager_result in zip(compiled_results, eager_results):
+        if abs(torch.mean(compiled_result) - torch.mean(eager_result)) > 0.001:
+            print("Compiled result does not match eager result")
+            return
+    print("Compiled result matches eager result!")
+
+
+def print_time_stats(times, *, warmup_iters: int = 0):
+    iter_times = torch.tensor(times[warmup_iters:])
+    print(f"Mean: {torch.mean(iter_times.to(float))} ns")
+    print(f"STD: {torch.std(iter_times.to(float))} ns")
+    print(f"Total: {torch.sum(iter_times)} ns")
+    print()


### PR DESCRIPTION
This commit adds the file `utils.py` to share the logic used by
`torchbench.py` to compile, time, and check the torchbench models with
other models not in torchbench. This commit also adds an script that runs
`Bert` on IREE and PyTorch eager.