### PR TITLE
Add torchdynamo.reset() when changing compilers

### DIFF
--- a/torchdynamo_poc/torchbench.py
+++ b/torchdynamo_poc/torchbench.py
@@ -97,6 +97,7 @@ def main():
         def run_model_eager():
             with torchdynamo.optimize("eager"):
                 return list(model.invoke())
+        torchdynamo.reset()
         eager_results = run(run_model_eager, total_iters)
         print("Eager iteration times")
         print_time_stats(EAGER_ITERATION_TIMES, warmup_iters=args.warmup_iters)


### PR DESCRIPTION
TorchDynamo now requires that `torchdynamo.reset()` be called when the
compiler passed to `torchdynamo.optimize` is changed.