### PR TITLE
Pass pytorch nightly url using --extra-index-url

### DIFF
--- a/torchdynamo_poc/requirements.txt
+++ b/torchdynamo_poc/requirements.txt
@@ -5,7 +5,7 @@ iree-runtime
 -f https://github.com/llvm/torch-mlir/releases
 torch-mlir
 
--f https://download.pytorch.org/whl/nightly/cpu
+--extra-index-url https://download.pytorch.org/whl/nightly/cpu
 --pre
 torch
 torchvision


### PR DESCRIPTION
If `-f` is used in `pip` rather than `--extra-index-url`, the right
`pillow` dependency is not installed.