### PR TITLE
[torchdynamo_poc] Print somewhat nicer timings

### DIFF
--- a/python/iree_torch/__init__.py
+++ b/python/iree_torch/__init__.py
@@ -78,7 +78,7 @@ class NumpyIREEInvoker:
         return invoke
 
 
-def compile_to_vmfb(mlir_module, target_backend="dylib"):
+def compile_to_vmfb(mlir_module, target_backend="llvm-cpu"):
     """Compile an MLIR module to an IREE Flatbuffer.
 
     The module is expected to be in the format produced by `torch_mlir.compile`
@@ -98,11 +98,11 @@ def _map_target_backend_to_driver(target_backend):
         return "cuda"
     if target_backend == "vulkan":
         return "vulkan"
-    if target_backend in ("dylib", "vmvx"):
+    if target_backend in ("llvm-cpu", "vmvx"):
         return "local-sync"
     raise ValueError(f"Unknown target backend: {target_backend}")
 
-def load_vmfb(flatbuffer, backend="dylib"):
+def load_vmfb(flatbuffer, backend="llvm-cpu"):
     """Load an IREE Flatbuffer into an in-process runtime wrapper.
 
     The wrapper accepts and returns `torch.Tensor` types.

--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -21,7 +21,7 @@ import torch_mlir
 import iree_torch
 
 
-DEVICE_TO_IREE_BACKEND = { "cpu" : "dylib",
+DEVICE_TO_IREE_BACKEND = { "cpu" : "llvm-cpu",
                            "cuda" : "cuda" }
 
 
@@ -107,7 +107,10 @@ def check_results(compiled_results, eager_results):
 
 def print_time_stats(times, *, warmup_iters: int = 0):
     iter_times = torch.tensor(times[warmup_iters:])
-    print(f"Mean: {torch.mean(iter_times.to(float))} ns")
-    print(f"STD: {torch.std(iter_times.to(float))} ns")
-    print(f"Total: {torch.sum(iter_times)} ns")
+    def quantile_ms(q):
+        return torch.quantile(iter_times.to(float), q).item() / 1e6
+    print(f"Median: {quantile_ms(0.5)} ms")
+    print(f"10%ile: {quantile_ms(0.1)} ms")
+    print(f"90%ile: {quantile_ms(0.9)} ms")
+    print(f"Total: {torch.sum(iter_times) / 1e6} ms")
     print()


### PR DESCRIPTION
Mean/standard deviation aren't great for performance tracking, since
they don't really have a very useful meaning in this context. Using
quantiles is more precise and interpretable.

Also, update to `llvm-cpu` backend name.