### PR TITLE
Remove warmup_iters arg from print_time_stats

### DIFF
--- a/torchdynamo_poc/bert.py
+++ b/torchdynamo_poc/bert.py
@@ -71,9 +71,9 @@ def main():
     eager_results, eager_iteration_times = benchmark_model(
         model, input_tensor, "eager", args.device, total_iters)
     print("Compiled iteration times")
-    print_time_stats(compiled_iteration_times, warmup_iters=args.warmup_iters)
+    print_time_stats(compiled_iteration_times[args.warmup_iters:])
     print("Eager iteration times")
-    print_time_stats(eager_iteration_times, warmup_iters=args.warmup_iters)
+    print_time_stats(eager_iteration_times[args.warmup_iters:])
 
     check_results(compiled_results, eager_results)
 

--- a/torchdynamo_poc/torchbench.py
+++ b/torchdynamo_poc/torchbench.py
@@ -86,7 +86,7 @@ def main():
     total_iters = args.warmup_iters + args.iters
     compiled_results = run(run_model_compiled, total_iters)
     print("Compiled iteration times")
-    print_time_stats(COMPILED_ITERATION_TIMES, warmup_iters=args.warmup_iters)
+    print_time_stats(COMPILED_ITERATION_TIMES[args.warmup_iters:])
 
     if args.check_with_eager:
         if args.device != "cpu":
@@ -100,7 +100,7 @@ def main():
         torchdynamo.reset()
         eager_results = run(run_model_eager, total_iters)
         print("Eager iteration times")
-        print_time_stats(EAGER_ITERATION_TIMES, warmup_iters=args.warmup_iters)
+        print_time_stats(EAGER_ITERATION_TIMES[args.warmup_iters:])
         check_results(compiled_results, eager_results)
 
 

--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -105,12 +105,11 @@ def check_results(compiled_results, eager_results):
     print("Compiled result matches eager result!")
 
 
-def print_time_stats(times, *, warmup_iters: int = 0):
-    iter_times = torch.tensor(times[warmup_iters:])
+def print_time_stats(times):
     def quantile_ms(q):
-        return torch.quantile(iter_times.to(float), q).item() / 1e6
+        return torch.quantile(times.to(float), q).item() / 1e6
     print(f"Median: {quantile_ms(0.5)} ms")
     print(f"10%ile: {quantile_ms(0.1)} ms")
     print(f"90%ile: {quantile_ms(0.9)} ms")
-    print(f"Total: {torch.sum(iter_times) / 1e6} ms")
+    print(f"Total: {torch.sum(times) / 1e6} ms")
     print()


### PR DESCRIPTION
It does not make much sense to have `print_time_stats` be responsible of removing warmup iteration times from the iteration times list. This commit removes the `warmup_iters` argument from the function.