### PR TITLE
Add README instructions for bert.py

### DIFF
--- a/torchdynamo_poc/README.md
+++ b/torchdynamo_poc/README.md
@@ -22,7 +22,8 @@ In a new venv:
 6. Install iree-torch. From the `iree-torch` root dir:
    - `python setup.py develop`
    
-If you want to use PyTorch+CUDA, first uninstall `torch`, `torchvision`, and `torchtext`, then install the nightly CUDA version. For example, for CUDA 11.6:
+If you want to use PyTorch+CUDA, first uninstall `torch`, `torchvision`, and
+`torchtext`, then install the nightly CUDA version. For example, for CUDA 11.6:
 
 ```
 python -m pip install --pre torch torchvision torchtext --extra-index-url https://download.pytorch.org/whl/nightly/cu116
@@ -30,8 +31,24 @@ python -m pip install --pre torch torchvision torchtext --extra-index-url https:
 
 # Running Torchbench Example
 
+This POC includes a script that runs PyTorch benchmarks using TorchDynamo to
+compile and run the models with IREE. An example for how to run the benchmark
+for the `hf_Bert` model is:
+
 ```
 python torchbench.py hf_Bert --trace --warmup-iters 5 --iters 10 --device=cuda
 ```
 
 For more info on the other flags supported, run `python torchbench.py -h`
+
+# Running Bert Example
+
+This POC includes a script that runs HuggingFace's Bert for language modeling
+using TorchDynamo to compile and run the model with IREE. The script compares
+the performance against PyTorch eager. An example usage of the script is:
+
+```
+python bert.py --device cuda --iters 10 --warmup-iters 5
+```
+
+For more info on the flags supported, run `python bert.py -h`.


### PR DESCRIPTION
This commit adds some instructions for running the `bert.py` script. It also does some formatting of the README and adds a description of what the `torchbench.py` file does.