### PR TITLE
Add CUDA LLVM target arch flag to `compile_to_vmfb`

### DIFF
--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -87,7 +87,8 @@ def torch_mlir_compiler(fx_graph: torch.fx.GraphModule,
     linalg_module = torch_mlir.compile(ts_graph, example_inputs,
                                        output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)
     backend = DEVICE_TO_IREE_BACKEND[device]
-    compiled_module = iree_torch.compile_to_vmfb(linalg_module, backend)
+    arch = "sm_80" if device == "cuda" else None
+    compiled_module = iree_torch.compile_to_vmfb(linalg_module, backend, arch)
     loaded_module = iree_torch.load_vmfb(compiled_module, backend)
 
     def forward(*inputs):


### PR DESCRIPTION
In order to get the best performance on CUDA, the CUDA LLVM target
architecture must be specified in the IREE compiler. This commit adds
support for specifying such a flag. In addition, it sets the flag to
`sm_80` in the TorchDynamo `utils.py`, since that target architecture
is needed to use NVIDIA's tensorcore.