### PR TITLE
Use torchdynamo decorator instead of context manager

### DIFF
--- a/torchdynamo_poc/bert.py
+++ b/torchdynamo_poc/bert.py
@@ -31,14 +31,14 @@ def run(func: Callable[[], List[torch.Tensor]], iters):
 
 
 def benchmark_model(model, input_tensor, compiler, device, iters):
-    model_device = model.to(device)
-    input_device = input_tensor.to(device)
+    model_on_device = model.to(device)
+    input_on_device = input_tensor.to(device)
 
     iteration_times = []
     @timeit(append_time_to=iteration_times)
+    @torchdynamo.optimize(compiler)
     def run_model_compiled():
-        with torchdynamo.optimize(compiler):
-            return model_device.forward(input_device)["logits"]
+        return model_on_device.forward(input_on_device)["logits"]
 
     torchdynamo.reset()
     compiled_results = run(run_model_compiled, iters)

--- a/torchdynamo_poc/torchbench.py
+++ b/torchdynamo_poc/torchbench.py
@@ -76,9 +76,9 @@ def main():
 
     compiled_iteration_times = []
     @timeit(append_time_to=compiled_iteration_times)
+    @torchdynamo.optimize(compiler)
     def run_model_compiled():
-        with torchdynamo.optimize(compiler):
-            return list(model.invoke())
+        return list(model.invoke())
 
     total_iters = args.warmup_iters + args.iters
     compiled_results = run(run_model_compiled, total_iters)
@@ -92,9 +92,9 @@ def main():
 
         eager_iteration_times = []
         @timeit(append_time_to=eager_iteration_times)
+        @torchdynamo.optimize("eager")
         def run_model_eager():
-            with torchdynamo.optimize("eager"):
-                return list(model.invoke())
+            return list(model.invoke())
         torchdynamo.reset()
         eager_results = run(run_model_eager, total_iters)
         print("Eager iteration times")


### PR DESCRIPTION
Using the context manager with TorchDynamo will soon be deprecated (https://github.com/pytorch/torchdynamo/commit/a2665c5fe11b91bb8d811303df52acd47bce5af2). The preferred method is to use the `torchdynamo.optimize` decorator. This commit updates the scripts to use the decorator.