### PR TITLE
Use `torch.allclose` to check results

### DIFF
--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -100,7 +100,7 @@ def torch_mlir_compiler(fx_graph: torch.fx.GraphModule,
 
 def check_results(compiled_results, eager_results):
     for compiled_result, eager_result in zip(compiled_results, eager_results):
-        if abs(torch.mean(compiled_result) - torch.mean(eager_result)) > 0.001:
+        if not torch.allclose(compiled_result, eager_result, atol=1e-5):
             print("Compiled result does not match eager result")
             return
     print("Compiled result matches eager result!")


### PR DESCRIPTION
This commit updates the `check_results` function to use `torch.allclose` to compare tensors.