### PR TITLE
Fix obsolete dylib backend, replacing with llvm-cpu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export PYTHONPATH="${IREE_BUILD_ROOT}/runtime/bindings/python:${IREE_BUILD_ROOT}
 
 Run the Torch-MLIR TorchScript e2e test suite on IREE:
 ```
-# Run all the tests on the default backend (`dylib`).
+# Run all the tests on the default backend (`llvm-cpu`).
 (iree-torch.venv) $ tools/e2e_test.sh
 # Run all tests on the `vmvx` backend.
 (iree-torch.venv) $ tools/e2e_test.sh --config vmvx

--- a/examples/bert.py
+++ b/examples/bert.py
@@ -64,13 +64,13 @@ def _get_argparse():
     parser.add_argument("--sentence",
                         default="The quick brown fox jumps over the lazy dog.",
                         help="sentence to run the model on.")
-    iree_backend_choices = ["dylib", "vmvx", "vulkan", "cuda"]
+    iree_backend_choices = ["llvm-cpu", "vmvx", "vulkan", "cuda"]
     parser.add_argument("--iree-backend",
         choices=iree_backend_choices,
-        default="dylib",
+        default="llvm-cpu",
         help=f"""
 Meaning of options:
-dylib - cpu, native code
+llvm-cpu - cpu, native code
 vmvx - cpu, interpreted
 vulkan - GPU for general GPU devices
 cuda - GPU for NVIDIA devices

--- a/tools/e2e_main.py
+++ b/tools/e2e_main.py
@@ -181,14 +181,14 @@ def dump_standalone_test_artifacts(artifact_dump_dir: str, tests):
 
 def _get_argparse():
     # TODO: Add CUDA and Vulkan.
-    config_choices = ['dylib', 'vmvx']
+    config_choices = ['llvm-cpu', 'vmvx']
     parser = argparse.ArgumentParser(description='Run torchscript e2e tests.')
     parser.add_argument('-c', '--config',
                         choices=config_choices,
-                        default='dylib',
+                        default='llvm-cpu',
                         help=f'''
 Meaning of options:
-"dylib": run through IREE's dylib backend
+"llvm-cpu": run through IREE's llvm-cpu backend
 "vmvx": run through IREE's VMVX backend
 ''')
     parser.add_argument('-f', '--filter', default='.*', help='''
@@ -226,8 +226,8 @@ def main():
             print(test.unique_name)
         sys.exit(1)
 
-    if args.config == "dylib":
-        iree_backend = IREELinalgOnTensorsBackend("dylib")
+    if args.config == "llvm-cpu":
+        iree_backend = IREELinalgOnTensorsBackend("llvm-cpu")
         xfail_set = DYLIB_XFAIL_SET
     elif args.config == "vmvx":
         iree_backend = IREELinalgOnTensorsBackend("vmvx")


### PR DESCRIPTION
This was breaking tests and the bert example.