### PR TITLE
Update functorch installation instructions

### DIFF
--- a/torchdynamo_poc/README.md
+++ b/torchdynamo_poc/README.md
@@ -18,7 +18,8 @@ In a new venv:
    - `python install.py --continue_on_fail`
    - Add this directory to your `PYTHONPATH` with: `echo $PWD > "$(python -c 'import site; print(site.getsitepackages()[0])')/torchbenchmark.pth"`
 5. Install functorch
-   - `python -m pip install "git+https://github.com/pytorch/functorch.git"`
+   - `python -m pip install -v "git+https://github.com/pytorch/pytorch.git@$(python -c "import torch.version; print(torch.version.git_version)")#subdirectory=functorch"`
+
 6. Install iree-torch. From the `iree-torch` root dir:
    - `python setup.py develop`
    


### PR DESCRIPTION
Functorch is in the process of getting moved into the PyTorch repository. This commit updates the installation instructions to install the `functorch` in the PyTorch directory rather than the `functorch` in the `functorch` repository, which can often fail to
install. See: https://github.com/pytorch/pytorch/issues/84882