### PR TITLE
Move input tensors to CPU device in `check_results`

### DIFF
--- a/torchdynamo_poc/utils.py
+++ b/torchdynamo_poc/utils.py
@@ -100,7 +100,8 @@ def torch_mlir_compiler(fx_graph: torch.fx.GraphModule,
 
 def check_results(compiled_results, eager_results):
     for compiled_result, eager_result in zip(compiled_results, eager_results):
-        if not torch.allclose(compiled_result, eager_result, atol=1e-5):
+        if not torch.allclose(compiled_result.to("cpu"),
+                              eager_result.to("cpu"), atol=1e-5):
             print("Compiled result does not match eager result")
             return
     print("Compiled result matches eager result!")


### PR DESCRIPTION
The op `torch.allclose` results in a runtime error if the two input tensors are not on the same device. This commit moves the input tensors of `torch.allclose` to the CPU device.