### PR TITLE
Add scripting support to `bert.py`

### DIFF
--- a/torchdynamo_poc/bert.py
+++ b/torchdynamo_poc/bert.py
@@ -62,7 +62,7 @@ def main():
     model = AutoModelForMaskedLM.from_config(config)
     model.eval()
 
-    compiler = make_torch_mlir_compiler(use_tracing=True, device=args.device)
+    compiler = make_torch_mlir_compiler(use_tracing=False, device=args.device)
 
     total_iters = args.warmup_iters + args.iters
     compiled_results, compiled_iteration_times = benchmark_model(


### PR DESCRIPTION
This commit adds support for running `bert.py` without needing to use tracing.