### PR TITLE
Add jupyter notebook with TorchDynamo demo

### DIFF
--- a/torchdynamo_poc/TorchDynamo Demo.ipynb
+++ b/torchdynamo_poc/TorchDynamo Demo.ipynb
@@ -1,0 +1,407 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "80cbcd88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchdynamo\n",
+    "import torch\n",
+    "from utils import make_torch_mlir_compiler\n",
+    "import torch_mlir\n",
+    "import iree_torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "02fb8e3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings, logging\n",
+    "warnings.simplefilter(\"ignore\")\n",
+    "torchdynamo.config.log_level = logging.ERROR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94b58c9d",
+   "metadata": {},
+   "source": [
+    "# Current Steps for Compiling in Torch-MLIR\n",
+    "\n",
+    "- Create a `torch.nn.Module`\n",
+    "- Ensure that module is scriptable or traceable (could require code changes)\n",
+    "- Compile module using `torch_mlir.compile` + `iree_torch.compile_to_vmfb`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c5ce9a40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MyModule(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "    def forward(self, t):\n",
+    "        return 2 * t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "de8728b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.5207, 0.9647, 0.7091],\n",
+       "        [0.8046, 0.4800, 0.7829]])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "example_input = torch.rand((2, 3))\n",
+    "example_input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ea683b1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.0413, 1.9294, 1.4181],\n",
+       "        [1.6091, 0.9600, 1.5658]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myModule = MyModule()\n",
+    "linalg_module = torch_mlir.compile(myModule, example_input, \n",
+    "                                   output_type=\"linalg-on-tensors\")\n",
+    "compiled_module = iree_torch.compile_to_vmfb(linalg_module)\n",
+    "loaded_module = iree_torch.load_vmfb(compiled_module)\n",
+    "loaded_module.forward(example_input)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba65a17a",
+   "metadata": {},
+   "source": [
+    "## Limitations\n",
+    "\n",
+    "- Input to `torch_mlir.compile` must be a `torch.nn.Module`\n",
+    "- Module must be scriptable or traceable\n",
+    "- Torch-MLIR is expected to support all of TorchScript (loops, control flow, etc)\n",
+    "\n",
+    "Note: TorchScript and Torch-MLIR do support single function workloads, but it requires a different path in Torch-MLIR and the API currently does not support it"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6028265",
+   "metadata": {},
+   "source": [
+    "# Steps using TorchDynamo\n",
+    "\n",
+    "- Add `torchdynamo.optimize` decorator (not limited to `torch.nn.Module`s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1f8c8509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torchdynamo.reset()\n",
+    "@torchdynamo.optimize(make_torch_mlir_compiler(use_tracing=False, device=\"cpu\", verbose=True))\n",
+    "def foo(t):\n",
+    "    return 2 * t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2882b8bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling graph...\n",
+      "torch.fx graph:\n",
+      "graph():\n",
+      "    %arg0_1 : [#users=1] = placeholder[target=arg0_1]\n",
+      "    %mul : [#users=1] = call_function[target=torch.ops.aten.mul](args = (%arg0_1, 2), kwargs = {})\n",
+      "    return mul\n",
+      "\n",
+      "\n",
+      "torch-mlir backend contract graph:\n",
+      "module attributes {torch.debug_module_name = \"_lambda\"} {\n",
+      "  func.func @forward(%arg0: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {\n",
+      "    %int2 = torch.constant.int 2\n",
+      "    %0 = torch.aten.mul.Scalar %arg0, %int2 : !torch.vtensor<[2,3],f32>, !torch.int -> !torch.vtensor<[2,3],f32>\n",
+      "    return %0 : !torch.vtensor<[2,3],f32>\n",
+      "  }\n",
+      "}\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.0413, 1.9294, 1.4181],\n",
+       "        [1.6091, 0.9600, 1.5658]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "foo(example_input)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4ba2cee",
+   "metadata": {},
+   "source": [
+    "## Graph Breaks\n",
+    "\n",
+    "Graph breaks allow running modules and functions with a mix of code expected to run on the backend and code expected to run at the Python level. This means Torch-MLIR does not have to worry about things like data dependent control flow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66d5d4a5",
+   "metadata": {},
+   "source": [
+    "### Example 1: Print statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "776c2ab2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torchdynamo.reset()\n",
+    "@torchdynamo.optimize(make_torch_mlir_compiler(use_tracing=False, device=\"cpu\", verbose=True))\n",
+    "def foo(a, b):\n",
+    "    print(\"Hello!\")\n",
+    "    return a + b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "964ddfde",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello!\n",
+      "Compiling graph...\n",
+      "torch.fx graph:\n",
+      "graph():\n",
+      "    %arg0_1 : [#users=1] = placeholder[target=arg0_1]\n",
+      "    %arg1_1 : [#users=1] = placeholder[target=arg1_1]\n",
+      "    %add : [#users=1] = call_function[target=torch.ops.aten.add](args = (%arg0_1, %arg1_1), kwargs = {})\n",
+      "    return add\n",
+      "\n",
+      "\n",
+      "torch-mlir backend contract graph:\n",
+      "module attributes {torch.debug_module_name = \"_lambda\"} {\n",
+      "  func.func @forward(%arg0: !torch.vtensor<[2,3],f32>, %arg1: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {\n",
+      "    %int1 = torch.constant.int 1\n",
+      "    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.int -> !torch.vtensor<[2,3],f32>\n",
+      "    return %0 : !torch.vtensor<[2,3],f32>\n",
+      "  }\n",
+      "}\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[1.5328, 1.4332, 1.1009],\n",
+       "        [1.0809, 0.7956, 0.9636]])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "foo(torch.rand((2, 3)), torch.rand((2, 3)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "111e855a",
+   "metadata": {},
+   "source": [
+    "This would not work in the current compilation flow from Torch-MLIR."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a97dc641",
+   "metadata": {},
+   "source": [
+    "### Example 2: Control flow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0a6d410b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torchdynamo.reset()\n",
+    "@torchdynamo.optimize(make_torch_mlir_compiler(use_tracing=False, device=\"cpu\", verbose=True))\n",
+    "def foo(a, b):\n",
+    "    x = a / (a + 1)\n",
+    "    if b.sum() < 0:\n",
+    "        b = b * -1\n",
+    "    return x * b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "79a1eef2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling graph...\n",
+      "torch.fx graph:\n",
+      "graph():\n",
+      "    %arg0_1 : [#users=2] = placeholder[target=arg0_1]\n",
+      "    %arg1_1 : [#users=1] = placeholder[target=arg1_1]\n",
+      "    %add : [#users=1] = call_function[target=torch.ops.aten.add](args = (%arg0_1, 1), kwargs = {})\n",
+      "    %div : [#users=1] = call_function[target=torch.ops.aten.div](args = (%arg0_1, %add), kwargs = {})\n",
+      "    %sum_1 : [#users=1] = call_function[target=torch.ops.aten.sum](args = (%arg1_1,), kwargs = {})\n",
+      "    %lt : [#users=1] = call_function[target=torch.ops.aten.lt](args = (%sum_1, 0), kwargs = {})\n",
+      "    return (div, lt)\n",
+      "\n",
+      "\n",
+      "torch-mlir backend contract graph:\n",
+      "module attributes {torch.debug_module_name = \"_lambda\"} {\n",
+      "  func.func @forward(%arg0: !torch.vtensor<[2,3],f32>, %arg1: !torch.vtensor<[2,3],f32>) -> (!torch.vtensor<[2,3],f32>, !torch.vtensor<[],i1>) {\n",
+      "    %int0 = torch.constant.int 0\n",
+      "    %int1 = torch.constant.int 1\n",
+      "    %none = torch.constant.none\n",
+      "    %0 = torch.aten.add.Scalar %arg0, %int1, %int1 : !torch.vtensor<[2,3],f32>, !torch.int, !torch.int -> !torch.vtensor<[2,3],f32>\n",
+      "    %1 = torch.aten.div.Tensor %arg0, %0 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32> -> !torch.vtensor<[2,3],f32>\n",
+      "    %2 = torch.aten.sum %arg1, %none : !torch.vtensor<[2,3],f32>, !torch.none -> !torch.vtensor<[],f32>\n",
+      "    %3 = torch.aten.lt.Scalar %2, %int0 : !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[],i1>\n",
+      "    return %1, %3 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[],i1>\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "Compiling graph...\n",
+      "torch.fx graph:\n",
+      "graph():\n",
+      "    %arg0_1 : [#users=1] = placeholder[target=arg0_1]\n",
+      "    %arg1_1 : [#users=1] = placeholder[target=arg1_1]\n",
+      "    %mul : [#users=1] = call_function[target=torch.ops.aten.mul](args = (%arg0_1, -1), kwargs = {})\n",
+      "    %mul_1 : [#users=1] = call_function[target=torch.ops.aten.mul](args = (%arg1_1, %mul), kwargs = {})\n",
+      "    return mul_1\n",
+      "\n",
+      "\n",
+      "torch-mlir backend contract graph:\n",
+      "module attributes {torch.debug_module_name = \"_lambda\"} {\n",
+      "  func.func @forward(%arg0: !torch.vtensor<[2,3],f32>, %arg1: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {\n",
+      "    %int-1 = torch.constant.int -1\n",
+      "    %0 = torch.aten.mul.Scalar %arg0, %int-1 : !torch.vtensor<[2,3],f32>, !torch.int -> !torch.vtensor<[2,3],f32>\n",
+      "    %1 = torch.aten.mul.Tensor %arg1, %0 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32> -> !torch.vtensor<[2,3],f32>\n",
+      "    return %1 : !torch.vtensor<[2,3],f32>\n",
+      "  }\n",
+      "}\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.0182, 0.2515, 0.0553],\n",
+       "        [0.0088, 0.2397, 0.0663]])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "foo(torch.rand((2, 3)), -torch.rand((2, 3)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "005037a0",
+   "metadata": {},
+   "source": [
+    "# Using `torch.fx` to Handle Torch-MLIR Limitations\n",
+    "\n",
+    "- Returning a single element tuple vs. returning a single tensor\n",
+    "- Functionalizing in-place reshapes\n",
+    "- Decomposing complex ops at the Python level with a few lines of code"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit adds a Jupyter notebook with some example of how to use TorchDynamo with Torch-MLIR + IREE, as well as how the process compares with the current Torch-MLIR Python API. This commit also adds some verbose support to the `make_torch_mlir_compiler` function to have a better idea of what is going on behind the scenes when running the Jupyter notebook.