### PR TITLE
Attempt to bring back the failing CI.

### DIFF
--- a/.github/workflows/test_nightly_packages.yml
+++ b/.github/workflows/test_nightly_packages.yml
@@ -24,4 +24,4 @@ jobs:
         python -m pip install -r $GITHUB_WORKSPACE/requirements.txt
     - name: Run Torch-MLIR E2E Tests
       run: |
-        $GITHUB_WORKSPACE/tools/e2e_test.sh -v
+        $GITHUB_WORKSPACE/tools/e2e_test.sh -v -s

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ numpy
 # For torchvision, use pillow<7 to avoid `ImportError: cannot import name 'PILLOW_VERSION' from 'PIL'`
 # See https://github.com/pytorch/vision/issues/1712
 pillow<7
+multiprocess


### PR DESCRIPTION
Aten_EmbeddingBagExample_basic is failing for mysterious reasons that don't reproduce with a local build. Unclear why.