### PR TITLE
Remove py3.9 or py3.10 requirement from bert notebook.

### DIFF
--- a/examples/bert.ipynb
+++ b/examples/bert.ipynb
@@ -27,23 +27,7 @@
         "id": "df1pAY3poNEq"
       },
       "source": [
-        "# Package Installation\n",
-        "\n",
-        "To install `torch-mlir` (required to compile the model to a format processable by IREE), your Python version must be 3.9 or 3.10.\n",
-        "\n",
-        "As of September 2022, Colab only runs on 3.7.  You must use a [local Colab runtime](https://research.google.com/colaboratory/local-runtimes.html) with the correct Python version for this notebook to work correctly."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "yHFrHZ1DfrT0"
-      },
-      "outputs": [],
-      "source": [
-        "import platform\n",
-        "assert platform.python_version().startswith('3.9.') or platform.python_version().startswith('3.10.')"
+        "# Package Installation"
       ]
     },
     {
@@ -68,7 +52,7 @@
       "source": [
         "# Model Setup\n",
         "\n",
-        "PyTorch models typically produce multiple outputs. Ome of them are only used during training, and some are only important for statistics tracking. For this model, only the next-token \"logits\" (which are basically just the next-token probabilities) are relevant."
+        "PyTorch models typically produce multiple outputs. Some of them are only used during training, and some are only important for statistics tracking. For this model, only the next-token \"logits\" (which are basically just the next-token probabilities) are relevant."
       ]
     },
     {


### PR DESCRIPTION
This is working now.  See https://github.com/llvm/torch-mlir/issues/1493

Also, fix a small typo.