### PR TITLE
Remove unncessary strip_overloads.

### DIFF
--- a/examples/regression.py
+++ b/examples/regression.py
@@ -78,15 +78,10 @@ def main():
     train_args = (w, b, X_test, y_test)
     graph = functorch.make_fx(train)(*train_args)
 
-    # TODO: Remove once https://github.com/llvm/torch-mlir/issues/1495
-    # is resolved.
-    strip_overloads(graph)
-
     linalg_on_tensors_mlir = torch_mlir.compile(
         graph,
         train_args,
-        output_type=torch_mlir.OutputType.LINALG_ON_TENSORS,
-        use_tracing=False)
+        output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)
 
     print("Loading into IREE")
     iree_vmfb = iree_torch.compile_to_vmfb(


### PR DESCRIPTION
No longer needed after https://github.com/llvm/torch-mlir/commit/e2de20575f92264f1131039a4d1393833a893f4c

Also, remove unnecessary use_tracing argument.