### PR TITLE
Fix grammar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An end-to-end example of compiling an `nn.Module`-based PyTorch BERT model to IR
 
 ## Native, On-device Training
 
-A small, self-contained binary can be built for deploying to resource-constrained environments can be found in [this example](https://github.com/iree-org/iree-torch/tree/main/examples/native_training).
+A small (~100-250KB), self-contained binary can be built for deploying to resource-constrained environments. An example illustrating this can be found in [this example](https://github.com/iree-org/iree-torch/tree/main/examples/native_training). This binary runs a model without a Python interpreter.
 
 # Planned features
 


### PR DESCRIPTION
Also, explain a couple more benefits of the native training example.